### PR TITLE
Create tf.constant from numpy

### DIFF
--- a/syft_tensorflow/hook/hook_args.py
+++ b/syft_tensorflow/hook/hook_args.py
@@ -26,7 +26,7 @@ type_rule = {
     TensorFlowTensor: one,
     EagerTensor: one,
     ResourceVariable: one,
-    np.ndarray: one,
+    np.ndarray: lambda x: 0,
 }
 
 def default_forward(i):
@@ -40,7 +40,6 @@ forward_func = {
     tf.Variable: default_forward,
     ResourceVariable: default_forward,
     EagerTensor: default_forward,
-    np.ndarray: default_forward,
 }
 backward_func = {
     tf.Tensor: lambda i: i.wrap(),
@@ -48,7 +47,6 @@ backward_func = {
     ResourceVariable: lambda i: i.wrap(),
     TensorFlowTensor: lambda i: i.wrap(),
     EagerTensor: lambda i: i.wrap(),
-    np.ndarray: lambda i: i.wrap(),
 }
 ambiguous_methods = {"__getitem__", "__setitem__"}
 

--- a/syft_tensorflow/hook/hook_args.py
+++ b/syft_tensorflow/hook/hook_args.py
@@ -4,6 +4,7 @@ See syft/generic/frameworks/hook/hook_args.py for the core implementation.
 """
 
 import tensorflow as tf
+import numpy as np
 
 from tensorflow.python.framework.ops import EagerTensor
 from syft.exceptions import PureFrameworkTensorFoundError
@@ -25,6 +26,7 @@ type_rule = {
     TensorFlowTensor: one,
     EagerTensor: one,
     ResourceVariable: one,
+    np.ndarray: one,
 }
 
 def default_forward(i):
@@ -38,6 +40,7 @@ forward_func = {
     tf.Variable: default_forward,
     ResourceVariable: default_forward,
     EagerTensor: default_forward,
+    np.ndarray: default_forward,
 }
 backward_func = {
     tf.Tensor: lambda i: i.wrap(),
@@ -45,6 +48,7 @@ backward_func = {
     ResourceVariable: lambda i: i.wrap(),
     TensorFlowTensor: lambda i: i.wrap(),
     EagerTensor: lambda i: i.wrap(),
+    np.ndarray: lambda i: i.wrap(),
 }
 ambiguous_methods = {"__getitem__", "__setitem__"}
 

--- a/syft_tensorflow/tensor/tensor_test.py
+++ b/syft_tensorflow/tensor/tensor_test.py
@@ -8,7 +8,15 @@ def test_send_get_constant(remote):
     x_to_give = tf.constant(2.0)
     x_ptr = x_to_give.send(remote)
     x_gotten = x_ptr.get()
+    
     assert tf.math.equal(x_to_give, x_gotten)
+
+def test_constant_with_numpy(remote):
+  x_to_give = tf.constant(np.ones([2,2]))
+  x_ptr = x_to_give.send(remote)
+  x_gotten = x_ptr.get()
+
+  assert tf.math.equal(x_to_give, x_gotten).numpy().all()
 
 def test_add(remote):
   x = tf.constant(2.0).send(remote)


### PR DESCRIPTION
Hey, 

By hooking numpy in hook_args, we can now create `tf.constant` tensors from numpy. 

Thanks,

Yann