### PR TITLE
Fix variable commands

### DIFF
--- a/syft_tensorflow/attributes/attributes.py
+++ b/syft_tensorflow/attributes/attributes.py
@@ -1,3 +1,4 @@
+import re
 from types import ModuleType
 import typing
 
@@ -106,11 +107,17 @@ class TensorFlowAttributes(FrameworkAttributes):
 
         self.command_guard = self._command_guard
 
-        self.exclude = []
-
+        self.inplace_re_pattern = re.compile("(assign)_?")
         self.inplace_methods = {}
 
 
-    def is_inplace_method(self, method):
-        # I've not yet encountered any inplace methods in TF
-        return False
+    def is_inplace_method(self, method_name):
+        try:
+            return self.inplace_methods[method_name]
+        except KeyError:
+            match = re.match(self.inplace_re_pattern, method_name)
+            if match is None:
+                return False
+            is_inplace = match.group(1)
+            self.inplace_methods[method_name] = is_inplace
+            return is_inplace

--- a/syft_tensorflow/hook/hook.py
+++ b/syft_tensorflow/hook/hook.py
@@ -214,18 +214,17 @@ class TensorFlowHook(FrameworkHook):
         self._hook_keras_methods(model_cls)
 
     def _hook_variable(self, syft_type: type):
-        """Adds PySyft Tensor Functionality to the given native tensor type.
-         Overloads the given native Torch tensor to add PySyft Tensor
-        Functionality. Overloading involves modifying the tensor type with
-        PySyft's added functionality. You may read about what kind of
-        modifications are made in the methods that this method calls.
-         Args:
-            tensor_type: The type of tensor being hooked (in this refactor
-                this is only ever torch.Tensor, but in previous versions of
-                PySyft this iterated over all tensor types.
+        """Adds PySyft Tensor functionality to tf.Variable.
+
+        In practice, the user is generally working with subclasses of
+        tf.Variable, e.g. ResourceVariable, so we hook methods for those and
+        only override the tf.Variable constructor to provide syft registration.
+        You may read about what kind of modifications are made in the methods
+        that this method calls.
+
+        Args:
             syft_type: The abstract type whose methods should all be added to
-                the tensor_type class. In practice this is always TorchTensor.
-                Read more about it there.
+                the ResourceVariable class.
         """
         # Reinitialize init method of Torch tensor with Syft init
         self._add_registration_to___init__(tf.Variable)

--- a/syft_tensorflow/hook/hook_args.py
+++ b/syft_tensorflow/hook/hook_args.py
@@ -52,7 +52,6 @@ backward_func = {
     tf.Tensor: lambda i: i.wrap(),
     tf.Variable: lambda i: i.wrap(),
     ResourceVariable: lambda i: i.wrap(),
-    TensorFlowTensor: lambda i: i.wrap(),
     EagerTensor: lambda i: i.wrap(),
     tf.keras.layers.Layer: lambda i: i.wrap(),
     tf.keras.models.Model: lambda i: i.wrap(),

--- a/syft_tensorflow/serde/serde_test.py
+++ b/syft_tensorflow/serde/serde_test.py
@@ -34,3 +34,10 @@ def test_serde_model():
     m_new = syft.serde.deserialize(ser)
 
     assert tf.math.equal(y, m_new(x)).numpy().all()
+
+
+def test_serde_dtype():
+    d = tf.float32
+    ser = syft.serde.serialize(d)
+    x = syft.serde.deserialize(ser)
+    assert d == x

--- a/syft_tensorflow/syft_types/variable_test.py
+++ b/syft_tensorflow/syft_types/variable_test.py
@@ -16,7 +16,24 @@ def test_add_variables(remote):
   z = z_ptr.get()
   assert np.array_equal(z.numpy(), [5., 5.])
 
+
 def test_variable_repr(remote):
   x = tf.Variable([1, 2, 3]).send(remote)
   repr = str(x)
   assert repr.startswith('(Wrapper)>[PointerTensor | me')
+
+
+def test_func_on_variables(remote):
+  x = tf.Variable([3.0, 3.0]).send(remote)
+  y = tf.Variable([2.0, 2.0]).send(remote)
+  z_ptr = tf.multiply(x, y)
+  z = z_ptr.get()
+  assert np.array_equal(z.numpy(), [6., 6.])
+
+
+def test_assign_variable(remote):
+  x = tf.Variable([3.0, 3.0]).send(remote)
+  y = tf.Variable([2.0, 2.0]).send(remote)
+  x.assign(y)
+  z = x.get()
+  assert np.array_equal(z.numpy(), [2., 2.])


### PR DESCRIPTION
TF functions like `tf.add` and non-dunder methods like `var.assign` were broken -- this should fix those.

Also added a regex to have `is_inplace_method` return True for  `var.assign` and similar methods.