### PR TITLE
Fix model repr and str

### DIFF
--- a/syft_tensorflow/hook/hook.py
+++ b/syft_tensorflow/hook/hook.py
@@ -208,6 +208,8 @@ class TensorFlowHook(FrameworkHook):
             "__setattr__",
             "__sizeof__",
             "__subclasshook__",
+            "__str__",
+            "__repr__",
         ]
         self._transfer_methods_to_framework_class(model_cls, from_cls, exclude)
 

--- a/syft_tensorflow/syft_types/keras_model_test.py
+++ b/syft_tensorflow/syft_types/keras_model_test.py
@@ -79,4 +79,21 @@ def test_keras_model_fit(remote):
     np.testing.assert_almost_equal(final_loss, 34.6580, decimal=4)
 
 
+def test_model_repr(remote):
+    model_to_give = tf.keras.models.Sequential([
+        tf.keras.layers.Dense(5, input_shape=[2])
+    ])
+    model_to_give_repr = str(model_to_give)
+
+    model_gotten = model_to_give.send(remote).get()
+    model_gotten_repr = str(model_gotten)
+
+    assert model_to_give_repr.startswith(
+        '<tensorflow.python.keras.engine.sequential.Sequential'
+    )
+    assert model_gotten_repr.startswith(
+        '<tensorflow.python.keras.engine.sequential.Sequential'
+    )
+
+
 


### PR DESCRIPTION
Hey,

I was getting a `maximum recursion depth ` error when printing or displaying a model after and before get. Probably because `__rpr__` and `__str_`_ where already hooked on Layer class (Model subclass it). 

Thanks