### PR TITLE
Switch to SavedModel for tf.keras.models.Model serde

### DIFF
--- a/syft_tensorflow/syft_types/keras_model_test.py
+++ b/syft_tensorflow/syft_types/keras_model_test.py
@@ -59,7 +59,7 @@ def test_keras_model_fit(remote):
     k_init = tf.keras.initializers.RandomNormal(seed=1)
 
     model_to_give = tf.keras.models.Sequential([
-                    tf.keras.layers.Dense(5, 
+                    tf.keras.layers.Dense(5,
                                           input_shape=[2],
                                           kernel_initializer=k_init)
     ])
@@ -67,7 +67,7 @@ def test_keras_model_fit(remote):
     model_to_give.compile(optimizer='adam',
                           loss='categorical_crossentropy',
                           metrics=['accuracy'])
-    
+
 
     model_ptr = model_to_give.send(remote)
     x_ptr = x_to_give.send(remote)
@@ -92,8 +92,5 @@ def test_model_repr(remote):
         '<tensorflow.python.keras.engine.sequential.Sequential'
     )
     assert model_gotten_repr.startswith(
-        '<tensorflow.python.keras.engine.sequential.Sequential'
+        '<tensorflow.python.keras.saving.saved_model.load.Sequential'
     )
-
-
-


### PR DESCRIPTION
Switches model serialization over to the SavedModel format, as opposed to hdf5.

With SavedModel, we can handle more general models, i.e.
```python
class CustomModel(tf.keras.Model):
    def __init__(self):
        self.layer = tf.keras.layers.Dense(3)
        self.scale = tf.Variable(2.)
    
    def call(self, x):
        return self.layer(x) * self.scale
```
or 
```python
class CustomModule(tf.Module):
    def __init__(self):
        self.layer = tf.keras.layers.Dense(3)
        self.scale = tf.Variable(2.)
    
    @tf.function
    def call(self, x):
        return self.layer(x) * self.scale
```

The hdf5 format cannot always handle these custom models, so we prefer to use SavedModel. 
 However, this implementation is much, much slower than the hdf5 implementation.  This is because we currently have to walk the entire SavedModel directory structure while serializing the model, and that walk is taking place in regular old Python.  There is probably a more efficient way to serialize the SavedModel directory, but we prefer to go forward with this in the meantime.  A future alternative could be to allow the user to control this behavior with a flag that switches between h5py & SavedModel simplifier/detailers, with h5py being the default for speed.